### PR TITLE
Add provide statement at the end of app-launcher.el

### DIFF
--- a/app-launcher.el
+++ b/app-launcher.el
@@ -188,3 +188,6 @@ When ARG is non-nil, ignore NoDisplay property in *.desktop files."
 		      (cdr (assq 'visible y))))
 		  t nil 'app-launcher nil nil)))
     (funcall app-launcher--action-function result)))
+
+;; Provide the app-launcher feature
+(provide 'app-launcher)


### PR DESCRIPTION
Hi @SebastienWae!  I just tried to pull in this package in my configuration and found that `use-package` can't load it because it doesn't contain a `(provide 'app-launcher)` expression at the bottom of the file.  I believe this fix should solve the problem!